### PR TITLE
Add a check to see if gdb is installed

### DIFF
--- a/truffleproc.sh
+++ b/truffleproc.sh
@@ -16,6 +16,8 @@ CONTAINER="${CONTAINER_IMAGE}@${CONTAINER_SHA}"
 main() {
   ensure_sudo
 
+  ensure_bin "gdb"
+
   echo "# coredumping pid ${PID}"
 
   coredump_pid
@@ -35,6 +37,10 @@ main() {
 
 ensure_sudo() {
   sudo touch /dev/null
+}
+
+ensure_bin() {
+  which "$1" > /dev/null
 }
 
 coredump_pid() {


### PR DESCRIPTION
This to help users to easily understand why nothing is happening
when they run the script and gdb isn't installed.

Signed-off-by: edvin norling <edvin.norling@gmail.com>